### PR TITLE
Fix deadlock occurring when two LogEventServer instances are involved.

### DIFF
--- a/plugins/log4j.viewer.core.json.tests/src/org/wtlnw/eclipse/log4j/viewer/core/json/test/TestJsonLogEventSupplierFactory.java
+++ b/plugins/log4j.viewer.core.json.tests/src/org/wtlnw/eclipse/log4j/viewer/core/json/test/TestJsonLogEventSupplierFactory.java
@@ -151,7 +151,7 @@ public class TestJsonLogEventSupplierFactory {
 		}
 
 		sema.acquire();
-		server.stop();
+		server.stop(true);
 		
 		if (!errors.isEmpty()) {
 			Assertions.fail(errors.getFirst());

--- a/plugins/log4j.viewer.core.tests/src/org/wtlnw/eclipse/log4j/viewer/core/impl/TestLogEventServer.java
+++ b/plugins/log4j.viewer.core.tests/src/org/wtlnw/eclipse/log4j/viewer/core/impl/TestLogEventServer.java
@@ -18,9 +18,12 @@ import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.BindException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import org.apache.logging.log4j.core.LogEvent;
@@ -111,9 +114,48 @@ public class TestLogEventServer {
 		}
 
 		sema.acquire();
-		server.stop();
+		server.stop(true);
 
 		Assertions.assertEquals(0, events.size());
+	}
+
+	@Test
+	void testMultipleServers() throws IOException, InterruptedException {
+		// start two servers (one would start and one would not) and then try to stop the second one
+		final Semaphore startTwo = new Semaphore(0);
+		final Semaphore stopBoth = new Semaphore(0);
+		final List<LogEvent> events = Collections.synchronizedList(new ArrayList<>());
+		final List<LogEventSupplierFactory> factories = List.of();
+		final LogEventServer serverOne = new LogEventServer(factories, events::add);
+		serverOne.addServerListener(started -> {
+			if (started) {
+				startTwo.release();
+			}
+		});
+		final LogEventServer serverTwo = new LogEventServer(factories, events::add);
+		serverTwo.addErrorListener((msg, ex) -> {
+			if (ex instanceof BindException) {
+				stopBoth.release();
+			}
+		});
+
+		// this one should succeed
+		serverOne.start();
+		startTwo.tryAcquire(serverOne.getTimeout() * 3, TimeUnit.MILLISECONDS);
+
+		Assertions.assertTrue(serverOne.isRunning());
+
+		// this one should fail
+		serverTwo.start();
+		stopBoth.tryAcquire(serverTwo.getTimeout() * 3, TimeUnit.MILLISECONDS);
+
+		Assertions.assertFalse(serverTwo.isRunning());
+
+		// both should terminate in a finite amount of time
+		Assertions.assertDoesNotThrow(() -> serverOne.stop(true));
+		Assertions.assertFalse(serverOne.isRunning());
+		
+		Assertions.assertThrows(IllegalStateException.class, () -> serverTwo.stop(true));
 	}
 	
 	@SuppressWarnings("deprecation")
@@ -154,7 +196,7 @@ public class TestLogEventServer {
 		}
 
 		sema.acquire();
-		server.stop();
+		server.stop(true);
 		
 		if (!errors.isEmpty()) {
 			Assertions.fail(errors.getFirst());
@@ -166,7 +208,7 @@ public class TestLogEventServer {
 		
 		Assertions.assertNotNull(events.get(2).getThrownProxy());
 	}
-	
+
 	private Configuration config(final String config) throws IOException {
 		try (final InputStream input = new ByteArrayInputStream(config.getBytes())) {
 			return ConfigurationFactory.getInstance().getConfiguration(null, new ConfigurationSource(input));

--- a/plugins/log4j.viewer.core.xml.tests/src/org/wtlnw/eclipse/log4j/viewer/core/xml/test/TestXmlLogEventSupplierFactory.java
+++ b/plugins/log4j.viewer.core.xml.tests/src/org/wtlnw/eclipse/log4j/viewer/core/xml/test/TestXmlLogEventSupplierFactory.java
@@ -151,8 +151,8 @@ public class TestXmlLogEventSupplierFactory {
 		}
 
 		sema.acquire();
-		server.stop();
-		
+		server.stop(true);
+
 		if (!errors.isEmpty()) {
 			Assertions.fail(errors.getFirst());
 		}

--- a/plugins/log4j.viewer.core/src/org/wtlnw/eclipse/log4j/viewer/core/impl/LogEventServer.java
+++ b/plugins/log4j.viewer.core/src/org/wtlnw/eclipse/log4j/viewer/core/impl/LogEventServer.java
@@ -237,8 +237,11 @@ public class LogEventServer {
 				// notify all registered listener of acceptor error
 				_errorListeners.forEach(l -> l.accept("Acceptor thread encountered an error, server is going down.", e));
 
-				// server socket is broken, terminate the server
-				stop();
+				// Server socket is broken, terminate the server.
+				// WARNING: do NOT await termination here because we're running
+				// in the context of the executor and would thus prevent it from
+				// terminating!
+				stop(false);
 			}
 		});
 	}
@@ -376,18 +379,23 @@ public class LogEventServer {
 	 * accepted connections.
 	 * 
 	 * <p>
-	 * Calling threads are blocked until all connections are terminated.
+	 * Note: this method must not be called with {@code true} from within the
+	 * acceptor or workers threads as doing so would block them indefinitely.
 	 * </p>
 	 * 
+	 * @param await {@code true} to block the calling thread until all connections
+	 *              are terminated, {@code false} to terminate without waiting
 	 * @throws IllegalStateException if the receiver was not started
 	 */
-	public synchronized void stop() throws IllegalStateException {
+	public synchronized void stop(final boolean await) throws IllegalStateException {
 		if (_executor == null) {
 			throw new IllegalStateException();
 		}
 
 		_executor.shutdown();
-		awaitTermination();
+		if (await) {
+			awaitTermination();
+		}
 		_executor = null;
 
 		// notify all registered listeners of server termination
@@ -413,7 +421,12 @@ public class LogEventServer {
 	/**
 	 * @return {@code true} if the receiver is running, {@code false} otherwise
 	 */
-	public synchronized boolean isRunning() {
-		return _executor != null && !_executor.isShutdown();
+	public boolean isRunning() {
+		// WARNING: do NOT inline this! We are assigning the reference
+		// to a local variable in order to perform two subsequent evaluations
+		// here and we don't want it to change midways.
+		final ExecutorService executor = _executor;
+		
+		return executor != null && !executor.isShutdown();
 	}
 }

--- a/plugins/log4j.viewer.ui/src/org/wtlnw/eclipse/log4j/viewer/ui/views/LogViewerPart.java
+++ b/plugins/log4j.viewer.ui/src/org/wtlnw/eclipse/log4j/viewer/ui/views/LogViewerPart.java
@@ -536,7 +536,7 @@ public class LogViewerPart extends ViewPart {
 				if (isChecked()) {
 					_server.start();
 				} else {
-					_server.stop();
+					_server.stop(true);
 				}
 			}
 		};
@@ -594,7 +594,7 @@ public class LogViewerPart extends ViewPart {
 	@Override
 	public void dispose() {
 		// stop the server and pause event updates
-		if (_server.isRunning()) _server.stop(); 
+		if (_server.isRunning()) _server.stop(true); 
 
 		// close all open dialogs
 		if (_dialogs != null) _dialogs.close();


### PR DESCRIPTION
When two LogEventServers are being started binding the same port, only one of them can succeed. The other one will catch the appropriate BindException and try to stop. However, stopping in this scenario won't work because the stop() method is called from within the thread which was started by the executor thus blocking the awaitTermination() method indefinitely.

So, when trying to ask the failed server isRunning() the calling thread would also block indefinitely, because the lock on the stop() method has not been released yet.